### PR TITLE
Resolves #12

### DIFF
--- a/lib/transliterator/string_unit/paragraph.dart
+++ b/lib/transliterator/string_unit/paragraph.dart
@@ -1,17 +1,19 @@
 part of transliterator;
 
 class Paragraph extends StringUnit with Superunit<Sentence>, Subunit<TextBlock> {
-  Paragraph(String content, {bool isComplete = true}) : super(content, isComplete: isComplete);
+  Paragraph(String content) : super(content);
 
   static const String optionalSentenceEndPunctuation = r'[…—.!?"”\)\]\}]';
   static const String requiredSentenceEndPunctuation = '[.!?]';
 
   @override
-  final Pattern splitPattern = RegExp('(.*?' // A sentence is a bit of text)'
+  final Pattern splitPattern = RegExp('(.*?' // A sentence is a bit of text'
       r'(?<![ .]\w)' // which doesn't end with only a single letter preceded by a period or whitespace,
       '$requiredSentenceEndPunctuation' // which has one of these required sentence ending punctuation marks
       '$optionalSentenceEndPunctuation*' // and is optionally followed by one or more of these punctuation marks
       r'\s+' // and then followed by one or more whitespace character
-      '|' // or
+      ')|(' // or
+      r'\n' //just a line break without anything else
+      ')|(' // or
       r'.+$)'); // anything leftover at the end of the string
 }

--- a/lib/transliterator/string_unit/sentence.dart
+++ b/lib/transliterator/string_unit/sentence.dart
@@ -1,7 +1,7 @@
 part of transliterator;
 
 class Sentence extends StringUnit with Superunit<Word>, Subunit<Paragraph> {
-  Sentence(String content, {bool isComplete = true}) : super(content, isComplete: isComplete);
+  Sentence(String content) : super(content);
 
   @override
   final Pattern splitPattern = RegExp(r'.+?(\s+|$)');

--- a/lib/transliterator/string_unit/string_unit.dart
+++ b/lib/transliterator/string_unit/string_unit.dart
@@ -2,43 +2,29 @@ part of transliterator;
 
 abstract class StringUnit {
   final String content;
-  final bool isComplete;
+  abstract final Pattern splitPattern;
 
-  StringUnit(this.content, {required this.isComplete});
+  StringUnit(this.content);
 
-  factory StringUnit.build(Type U, String content, {required bool isComplete}) {
+  Iterable<Match> splitIntoSubunits() => splitPattern.allMatches(content);
+
+  factory StringUnit.build(Type U, String content) {
     switch (U) {
       case TextBlock:
-        return TextBlock(content, isComplete: isComplete);
+        return TextBlock(content);
       case Paragraph:
-        return Paragraph(content, isComplete: isComplete);
+        return Paragraph(content);
       case Sentence:
-        return Sentence(content, isComplete: isComplete);
+        return Sentence(content);
       case Word:
-        return Word(content, isComplete: isComplete);
+        return Word(content);
       default:
         throw TypeError();
     }
   }
 
-  //FIXME: This is terrible, since what it's really doing is returning the patternMatches for the Subunit of the type passed in. I need a better way to set it up so that I can run the patternMatches on the appropriate Regex without having to have an instance of the Subunit or a canonical Type for it.
-  static bool matchesEndPattern(Type U, String content) {
-    bool patternMatches(Pattern pattern, String string) => pattern.allMatches(string).isNotEmpty;
-
-    switch (U) {
-      case TextBlock:
-        return patternMatches(RegExp(r'\n$'), content);
-      case Paragraph:
-        return patternMatches(RegExp('${Paragraph.requiredSentenceEndPunctuation}${Paragraph.optionalSentenceEndPunctuation}*\$'), content);
-      case Sentence:
-        return patternMatches(RegExp(r'[^\w\s]$'), content);
-      default:
-        return patternMatches(RegExp(r'$'), content);
-    }
-  }
-
   //FIXME: This doesn't work for passing in Subunit<U> generics.
-  U cast<U extends StringUnit>() => StringUnit.build(U, content, isComplete: isComplete) as U;
+  U cast<U extends StringUnit>() => StringUnit.build(U, content) as U;
 
   @override
   String toString() => content;

--- a/lib/transliterator/string_unit/super_unit.dart
+++ b/lib/transliterator/string_unit/super_unit.dart
@@ -1,7 +1,3 @@
 part of transliterator;
 
-mixin Superunit<S extends StringUnit> implements StringUnit {
-  abstract final Pattern splitPattern;
-
-  Iterable<Match> splitIntoSubunits() => splitPattern.allMatches(content);
-}
+mixin Superunit<S extends StringUnit> implements StringUnit {}

--- a/lib/transliterator/string_unit/text_block.dart
+++ b/lib/transliterator/string_unit/text_block.dart
@@ -1,7 +1,7 @@
 part of transliterator;
 
 class TextBlock extends StringUnit with Superunit<Paragraph> {
-  TextBlock(String content, {bool isComplete = true}) : super(content, isComplete: isComplete);
+  TextBlock(String content) : super(content);
 
   @override
   final Pattern splitPattern = RegExp(r'.+?(\n|$)');

--- a/lib/transliterator/string_unit/word.dart
+++ b/lib/transliterator/string_unit/word.dart
@@ -1,5 +1,8 @@
 part of transliterator;
 
 class Word extends StringUnit with Subunit<Sentence> {
-  Word(String content, {bool isComplete = true}) : super(content, isComplete: isComplete);
+  Word(String content) : super(content);
+
+  @override
+  Pattern get splitPattern => '';
 }

--- a/lib/transliterator/transliterator/string/paragraph_transliterator.dart
+++ b/lib/transliterator/transliterator/string/paragraph_transliterator.dart
@@ -21,5 +21,5 @@ class ParagraphTransliterator<S extends Language, T extends Language> extends St
   SentenceTransliterator<S, T> getSubtransliterator() => SentenceTransliterator.fromTransliterator<S, T>(this);
 
   @override
-  Paragraph buildUnit(String string, {required bool isComplete}) => Paragraph(string, isComplete: isComplete);
+  Paragraph buildUnit(String string) => Paragraph(string);
 }

--- a/lib/transliterator/transliterator/string/sentence_transliterator.dart
+++ b/lib/transliterator/transliterator/string/sentence_transliterator.dart
@@ -26,19 +26,17 @@ class SentenceTransliterator<S extends Language, T extends Language> extends Str
     final String? sentenceWords = sentencePunctuationMatches?.group(2);
     final String? closingPunctuation = sentencePunctuationMatches?.group(3);
     final Result<Sentence, S, T> wordResult = splitMapJoin(sentenceWords != null ? Sentence(sentenceWords) : input,
-        onMatch: (Match match) => wordTransliterator.transliterate(wordTransliterator.buildUnit(match[0]!, isComplete: true)),
-        onNonMatch: cleanNonWordCharacters);
+        onMatch: (Match match) => wordTransliterator.transliterate(wordTransliterator.buildUnit(match[0]!)), onNonMatch: cleanNonWordCharacters);
 
     final int openingQuoteIndex = (openingPunctuation ?? '').indexOf(openingQuotePattern);
     final String newOpeningPunctuation =
         '${(openingPunctuation ?? '').substring(0, openingQuoteIndex + 1)}${openingQuoteIndex > -1 ? '' : leadingPeriod}${(openingPunctuation ?? '').substring(openingQuoteIndex + 1)}';
     final Result<Sentence, S, T> openingPunctuationResult = wordResult is EmptyResult
-        ? ResultPair<Sentence, S, T>.fromValue(buildUnit('', isComplete: false))
-        : ResultPair<Sentence, S, T>(buildUnit(openingPunctuation ?? '', isComplete: false), buildUnit(newOpeningPunctuation, isComplete: false));
+        ? ResultPair<Sentence, S, T>.fromValue(buildUnit(''))
+        : ResultPair<Sentence, S, T>(buildUnit(openingPunctuation ?? ''), buildUnit(newOpeningPunctuation));
     final Result<Sentence, S, T> closingPunctuationResult = closingPunctuation != null
-        ? ResultPair<Sentence, S, T>(
-            buildUnit(closingPunctuation, isComplete: false), buildUnit(closingPunctuation.replaceFirst(RegExp('[!.]+'), ''), isComplete: false))
-        : ResultPair<Sentence, S, T>.fromValue(buildUnit('', isComplete: false));
+        ? ResultPair<Sentence, S, T>(buildUnit(closingPunctuation), buildUnit(closingPunctuation.replaceFirst(RegExp('[!.]+'), '')))
+        : ResultPair<Sentence, S, T>.fromValue(buildUnit(''));
 
     final Result<Sentence, S, T> finalResult = Result.join<Sentence, S, T>(
         <Result<Sentence, S, T>>[openingPunctuationResult, wordResult, closingPunctuationResult],
@@ -99,5 +97,5 @@ class SentenceTransliterator<S extends Language, T extends Language> extends Str
   WordTransliterator<S, T> getSubtransliterator() => WordTransliterator.fromTransliterator(this);
 
   @override
-  Sentence buildUnit(String string, {required bool isComplete}) => Sentence(string, isComplete: isComplete);
+  Sentence buildUnit(String string) => Sentence(string);
 }

--- a/lib/transliterator/transliterator/string/string_transliterator.dart
+++ b/lib/transliterator/transliterator/string/string_transliterator.dart
@@ -17,11 +17,11 @@ abstract class StringTransliterator<Unit extends StringUnit, S extends Language,
     Writer debugWriter = const StderrWriter(),
   }) : super(mode: mode, dictionary: dictionary, outputWriter: outputWriter, debugWriter: debugWriter);
 
-  Unit buildUnit(String string, {required bool isComplete});
+  Unit buildUnit(String string);
 
-  Unit sourceReducer(Unit a, Unit b) => buildUnit('$a$b', isComplete: b.isComplete);
+  Unit sourceReducer(Unit a, Unit b) => buildUnit('$a$b');
 
-  Unit targetReducer(Unit a, Unit b) => buildUnit('$a$b', isComplete: b.isComplete);
+  Unit targetReducer(Unit a, Unit b) => buildUnit('$a$b');
 
   @override
   Result<Unit, S, T> transliterate(Unit input, {bool useOutputWriter = false});
@@ -34,7 +34,7 @@ abstract class StringTransliterator<Unit extends StringUnit, S extends Language,
 mixin SuperUnitStringTransliterator<U extends StringUnit, S extends Language, T extends Language> on StringTransliterator<U, S, T> {
   SubTrans<U, S, T> getSubtransliterator();
 
-  Subunit<U> buildSubunit(String string, {required bool isComplete}) => getSubtransliterator().buildUnit(string, isComplete: isComplete);
+  Subunit<U> buildSubunit(String string) => getSubtransliterator().buildUnit(string);
 
   @override
   Result<U, S, T> transliterate(U input, {bool useOutputWriter = false}) => splitMapJoin(input);
@@ -46,15 +46,15 @@ mixin SuperUnitStringTransliterator<U extends StringUnit, S extends Language, T 
     SubResult<U, S, T> Function(Match match)? onMatch,
   }) {
     final SubTrans<U, S, T> subtransliterator = getSubtransliterator();
-    onMatch ??= (Match match) => subtransliterator.transliterate(buildSubunit(match[0]!, isComplete: true));
-    onNonMatch ??= (String nonMatch) => ResultPair<Subunit<U>, S, T>.fromValue(buildSubunit(nonMatch, isComplete: false));
+    onMatch ??= (Match match) => subtransliterator.transliterate(buildSubunit(match[0]!));
+    onNonMatch ??= (String nonMatch) => ResultPair<Subunit<U>, S, T>.fromValue(buildSubunit(nonMatch));
 
-    final Iterable<Match> matches = (input as Superunit<Subunit<U>>).splitIntoSubunits();
+    final Iterable<Match> matches = input.splitIntoSubunits();
     int previousMatchEnd = 0;
 
     //if nothing matched, then treat the entire input as a nonMatch and return a corresponding Result.
     if (matches.isEmpty) {
-      return onNonMatch(input.content).cast<U>((Subunit<U> subunit) => buildUnit(subunit.content, isComplete: false));
+      return onNonMatch(input.content).cast<U>((Subunit<U> subunit) => buildUnit(subunit.content));
     }
 
     Iterable<SubResult<U, S, T>> results() sync* {
@@ -78,7 +78,7 @@ mixin SuperUnitStringTransliterator<U extends StringUnit, S extends Language, T 
     )).cast<U>((Subunit<U> subunit) => subunit.cast<U>());
   }
 
-  // TODO: The type constraint on this is weaker than it should be. Ideally it'd accept List<Atom<Unit, X>>, but if it gets passed something of type Subunit<E> where E is the superunit of Unit, it won't accept those as being the same. The weaker type restriction is a work around until I figure out a better solution. Additionally the Superunit<Subunit<Unit>> casts are hacks because `splitIntoSubunits` is only defined on Superunits and I lack the ability to properly add the constraint that asserts that Unit is a Superunit
+  // TODO: The type constraint on this is weaker than it should be. Ideally it'd accept List<Atom<Unit, X>>, but if it gets passed something of type Subunit<E> where E is the superunit of Unit, it won't accept those as being the same. The weaker type restriction is a work around until I figure out a better solution.
   /// Takes a [List] of [Atom]s whose contents collectively represent one [StringUnit]'s content, and returns the results of transliteration on them.
   Iterable<AtomResult<U, X, S, T>?> transliterateAtoms<X>(List<Atom<StringUnit, X>?> unitAtoms) {
     final SubTrans<U, S, T> subtransliterator = getSubtransliterator();
@@ -102,70 +102,59 @@ mixin SuperUnitStringTransliterator<U extends StringUnit, S extends Language, T 
     }
   }
 
-  /// Decomposes [unitAtoms], which is a [List] o f [Atom]s whose contents collectively represent one [StringUnit]'s content into a matrix of [Subunit<StringUnit>] Atoms. The element `matrix[i][j]` represents the part of the ith Subunit in the collective StringUnit whose contents are located in the jth Atom of the the collective StringUnit.
+  /// Decomposes [unitAtoms], which is a [List] of [Atom]s whose contents collectively represent one [StringUnit]'s content into a matrix of [Subunit<StringUnit>] Atoms. The element `matrix[i][j]` represents the part of the ith Subunit in the collective StringUnit whose contents are located in the jth Atom of the the collective StringUnit.
   Matrix<SubAtom<U, X>?> _breakUnitAtomsIntoSubunitUnitMatrix<X>(List<Atom<StringUnit, X>?> unitAtoms) {
     final Matrix<SubAtom<U, X>?> subunitUnitMatrix = <List<SubAtom<U, X>?>>[];
     int subunitNumber = 0;
-    bool subunitIsComplete = true;
     for (int unitAtomNumber = 0; unitAtomNumber < unitAtoms.length; unitAtomNumber++) {
       if (unitAtoms[unitAtomNumber] == null) {
         continue;
       }
+      final bool isLastUnitAtom = unitAtomNumber == unitAtoms.length - 1;
       final X unitAtomContext = unitAtoms[unitAtomNumber]!.context; // This context will get passed to all subAtoms created from this Atom.
-      final List<Match> subunitMatches = (unitAtoms[unitAtomNumber]!.content as Superunit<Subunit<U>>).splitIntoSubunits().toList();
+      final List<Match> subunitMatches = unitAtoms[unitAtomNumber]!.content.splitIntoSubunits().toList();
+      final Atom<StringUnit, X>? nextUnitAtom = isLastUnitAtom ? null : unitAtoms[unitAtomNumber + 1];
+      final String nextUnitAtomContent = nextUnitAtom?.content.content ?? '';
+      // Create an "extended unit" which is this unit combined with the next one.
+      final String extendedUnitContent = unitAtoms[unitAtomNumber]!.content.content + nextUnitAtomContent;
+      // And split that extended unit into subunits. These "extended subunits" can be used to see a subunit extends across the atom boundary, or the subunit ends at the same place as the unit does.
+      final List<Match> extendedSubunitMatches = (buildUnit(extendedUnitContent)).splitIntoSubunits().toList();
       final int subunitCount = subunitNumber + subunitMatches.length;
-
       //On a new unitAtom, we need to add new subunit rows to the matrix of length equal to the total atom count.
       subunitUnitMatrix.addAll(
         Iterable<List<SubAtom<U, X>?>>.generate(
-          subunitIsComplete ? subunitMatches.length : subunitMatches.length - 1,
+          subunitMatches.length,
           (int i) => List<SubAtom<U, X>?>.filled(unitAtoms.length, null),
         ),
       );
-      for (final Match subunitMatch in subunitMatches) {
-        final String subunitContents = subunitMatch.group(0) ?? '';
-        //Because we define as a constraint to the problem space that a subunit can not span multiple units (which is a distinct statement from saying that it can't span multiple unit atoms, which is allowed), we well consider a subunit as complete if it's the last subunit of the last atom for the unit. For example, the last bit of text in a paragraph will be considered a complete sentence even if it does not otherwise have punctuation indicating such. Additionally, any subunits which do not reach the end of this unit will always be complete, as that completeness is a requisite feature of what it means for them to be able to have been split in the first place.
-        subunitIsComplete = subunitNumber < subunitCount - 1 ||
-            unitAtomNumber == unitAtoms.length - 1 && subunitNumber == subunitCount - 1 ||
-            StringUnit.matchesEndPattern(U, subunitContents);
-        final SubAtom<U, X> subunitAtom = Atom<Subunit<U>, X>(buildSubunit(subunitContents, isComplete: subunitIsComplete), unitAtomContext);
-        subunitUnitMatrix[subunitNumber][unitAtomNumber] = subunitAtom;
-        // Some subunit end patterns have optional characters after the required ones. If a an atom break occurs somewhere after the required character, but before all of the optional characters, then the subunit will be considered to be broken prematurely. To avoid this, the content of the next unitAtom needs to be checked to see if it starts with any of the optional characters. If it does, then the following needs to occur:
-        // 1) The subunitAtom we just made also needs to have its `isComplete` value changed to indicate that it wasn't quite done yet.
-        // 2) Those characters need to be extracted from that atom and inserted into the matrix as part of _this_ subunit. They can not be left for the next atom to process, since it would have no way of knowing if those characters should belong to the previous atom instead.
-        // 3) The next unitAtom's content then needs to be updated to no longer include those extracted characters so that it starts at the correct point.
-        // Only run this special logic if this is the last subunit of the atom, there is another atom after it, and we identified the subunit as complete.
-        if (subunitMatch == subunitMatches.last && unitAtomNumber < unitAtoms.length - 1 && subunitIsComplete) {
+      for (int subunitMatchIndex = 0; subunitMatchIndex < subunitMatches.length; subunitMatchIndex++) {
+        final bool isLastSubunit = subunitNumber == subunitCount - 1;
+        final String subunitContent = subunitMatches[subunitMatchIndex].group(0) ?? '';
+        // For the last subunit of an atom which is followed by a non-null atom, we need to figure out if the subunit is complete.
+        if (isLastSubunit && nextUnitAtom != null) {
           //Calculate what this subunit's content would have been if we included the next unitAtom's content as well.
-          final Atom<StringUnit, X> nextUnitAtom = unitAtoms[unitAtomNumber + 1]!;
-          final String nextUnitAtomContent = nextUnitAtom.content.content;
-          final String extendedSubunitContents = subunitContents + nextUnitAtomContent;
-          final Iterable<Match> extendedSubunitMatches = (buildUnit(extendedSubunitContents, isComplete: true) as Superunit<Subunit<U>>).splitIntoSubunits();
-          final Match firstExtendedSubunitMatch = extendedSubunitMatches.first;
-          final int firstExtendedSubunitLength = firstExtendedSubunitMatch.end - firstExtendedSubunitMatch.start;
-          // Test to see if this new alternative content would have differed from the original
-          final int extraExtendedSubunitMatchCharacters = firstExtendedSubunitLength - subunitContents.length;
-          if (extraExtendedSubunitMatchCharacters > 0) {
-            // At this point, we've detected that the next UnitAtom contains a little bit more of this Subunit, so we need to do the necessary work to adjust for that.
-            // 1) Fix old subunitAtom's isComplete value
-            final SubAtom<U, X> revisedSubunitAtom = Atom<Subunit<U>, X>(buildSubunit(subunitContents, isComplete: false), unitAtomContext);
-            subunitUnitMatrix[subunitNumber][unitAtomNumber] = revisedSubunitAtom;
-            // 2) Add a SubAtom to the matrix for the extra bit of this Subunit in the next Atom.
+          final int extendedSubunitMatchLength = extendedSubunitMatches[subunitMatchIndex].end - extendedSubunitMatches[subunitMatchIndex].start;
+          final int extraExtendedSubunitMatchCharacters = extendedSubunitMatchLength - subunitContent.length;
+          // Test to see if this new alternative content would have differed from the original. If there is more to this subunit, and the next atom would complete it (which means the extended unit can be split more than the original unit could), we need to make an extra subunitAtom for it and remove those bits from the next Atom.
+          if (extraExtendedSubunitMatchCharacters > 0 && subunitMatches.length < extendedSubunitMatches.length) {
+            // Add a SubAtom to the matrix for the extra bit of this Subunit which was in the next Atom.
             final SubAtom<U, X> extraSubunitAtom = Atom<Subunit<U>, X>(
-              buildSubunit(nextUnitAtomContent.substring(0, extraExtendedSubunitMatchCharacters), isComplete: true),
-              unitAtomContext,
+              buildSubunit(nextUnitAtomContent.substring(0, extraExtendedSubunitMatchCharacters)),
+              nextUnitAtom.context,
             );
             subunitUnitMatrix[subunitNumber][unitAtomNumber + 1] = extraSubunitAtom;
-            // 3) Removed those extracted characters from from the next UnitAtom's content.
+            // Remove those extracted characters from from the next UnitAtom's content.
             unitAtoms[unitAtomNumber + 1] = nextUnitAtom.withNewContent(StringUnit.build(
               U,
               nextUnitAtomContent.substring(extraExtendedSubunitMatchCharacters),
-              isComplete: true,
             ));
           }
         }
-        // Now that we are sure that we've reached the end of the subunit, we can move onto the next.
-        if (subunitIsComplete) {
+        // Create a subunit atom of the content for this subunit in this unitAtom
+        final SubAtom<U, X> subunitAtom = Atom<Subunit<U>, X>(buildSubunit(subunitContent), unitAtomContext);
+        subunitUnitMatrix[subunitNumber][unitAtomNumber] = subunitAtom;
+        // Increment the subunitNumber if this subunitMatch was the last one in the unit atom (because we have logic above to "complete" partial subunits which span to the next unit atom, this effectively means that the subunitMatch will be the last in the subunit there are more matches in this atom, or if the extended unit has more matches than the unit does.
+        if (subunitMatches.length < extendedSubunitMatches.length || subunitMatchIndex < subunitMatches.length - 1) {
           subunitNumber++;
         }
       }
@@ -194,7 +183,7 @@ mixin SuperUnitStringTransliterator<U extends StringUnit, S extends Language, T 
     for (int subunitNumber = 0; subunitNumber < subunitUnitMatrix.length; subunitNumber++) {
       // A list of the subunit atoms which comprise the entire subunit, indexed by which unitAtom it came from.
       final List<SubAtom<U, X>?> subunitAtoms = subunitUnitMatrix[subunitNumber];
-      if (subunitAtoms.isNotEmpty) {
+      if (subunitAtoms.isNotEmpty && subunitAtoms.any((SubAtom<U, X>? subAtom) => subAtom != null)) {
         //A list of transliterated subunit atoms results which comprise the entire subunit, indexed by which unitAtom it came from.
         final List<SubAtomResult<U, X, S, T>?> transliteratedSubunitAtoms = subtransliterator.transliterateAtoms<X>(subunitAtoms).toList();
         for (int unitNumber = 0; unitNumber < transliteratedSubunitAtoms.length; unitNumber++) {

--- a/lib/transliterator/transliterator/string/text_block_transliterator.dart
+++ b/lib/transliterator/transliterator/string/text_block_transliterator.dart
@@ -21,5 +21,5 @@ class TextBlockTransliterator<S extends Language, T extends Language> extends St
   ParagraphTransliterator<S, T> getSubtransliterator() => ParagraphTransliterator.fromTransliterator<S, T>(this);
 
   @override
-  TextBlock buildUnit(String string, {required bool isComplete}) => TextBlock(string, isComplete: isComplete);
+  TextBlock buildUnit(String string) => TextBlock(string);
 }

--- a/lib/transliterator/transliterator/string/word_transliterator.dart
+++ b/lib/transliterator/transliterator/string/word_transliterator.dart
@@ -34,7 +34,7 @@ class WordTransliterator<S extends Language, T extends Language> extends StringT
   }
 
   @override
-  Word buildUnit(String string, {required bool isComplete}) => Word(string, isComplete: isComplete);
+  Word buildUnit(String string) => Word(string);
 
   /// Computes the transliteration [Result] of the given [word] based on the options set in this [WordTransliterator]'s [Mode].
   Result<Word, S, T> _transliterateWord(Word word) {
@@ -84,14 +84,14 @@ class WordTransliterator<S extends Language, T extends Language> extends StringT
       transliteratedWord.write(nextOption.target.first);
     }
 
-    return ResultPair<Word, S, T>(input, buildUnit(transliteratedWord.toString(), isComplete: true));
+    return ResultPair<Word, S, T>(input, buildUnit(transliteratedWord.toString()));
   }
 
   /// Gets all the possible ways the [input] word might be transliterated.
   ///
   /// This only cares if a transliteration is possible, not if it is likely. If the [input] can be transliterated in multiple ways, the most likely transliteration will be the first element of the [ResultSet.target], but the remaining options will ordered arbitrarily.
-  Result<Word, S, T> getFullResult(Word input) => Result<Word, S, T>.fromIterable(
-      input, _getSubwordTransliterations(input.content, _getOptionSetMapForString(input.content)).map((String string) => buildUnit(string, isComplete: true)));
+  Result<Word, S, T> getFullResult(Word input) =>
+      Result<Word, S, T>.fromIterable(input, _getSubwordTransliterations(input.content, _getOptionSetMapForString(input.content)).map(buildUnit));
 
   /// Returns all possible transliterations for a given [input].
   ///


### PR DESCRIPTION
Rewrote the StringTransliteror.transliterateAtoms() function to have logic that consumes orphaned bits of a subunit in the next unit's atom.
Removed StringUnit.matchesEndPattern() and replaced uses of it with StringUnit.splitIntoSubunits().
Removed StringUnit.isComplete field, since it wasn't actually used for anything anymore.