### PR TITLE
Resolves #28

### DIFF
--- a/lib/scripts/unicode.dart
+++ b/lib/scripts/unicode.dart
@@ -1,7 +1,7 @@
 abstract class Unicode {
   static const String emDash = '\u2014';
   static const String ellipsis = '\u2026';
-  static const String zeroWidthNoneBreakingSpace = '\u2060';
+  static const String zeroWidthNonBreakingSpace = '\u2060';
 }
 
 //https://docs.oracle.com/cd/E29584_01/webhelp/mdex_basicDev/src/rbdv_chars_mapping.html is a good list of foreign characters and the best ascii mapping of them. Eventually I should make links in the font for all of these.

--- a/lib/transliterator/string_unit/text_block.dart
+++ b/lib/transliterator/string_unit/text_block.dart
@@ -4,5 +4,5 @@ class TextBlock extends StringUnit with Superunit<Paragraph> {
   TextBlock(String content) : super(content);
 
   @override
-  final Pattern splitPattern = RegExp(r'.+?(\n|$)');
+  final Pattern splitPattern = RegExp(r'.+?(\n?\r?\n|$)');
 }

--- a/lib/transliterator/transliterator/string/string_transliterator.dart
+++ b/lib/transliterator/transliterator/string/string_transliterator.dart
@@ -153,8 +153,12 @@ mixin SuperUnitStringTransliterator<U extends StringUnit, S extends Language, T 
         // Create a subunit atom of the content for this subunit in this unitAtom
         final SubAtom<U, X> subunitAtom = Atom<Subunit<U>, X>(buildSubunit(subunitContent), unitAtomContext);
         subunitUnitMatrix[subunitNumber][unitAtomNumber] = subunitAtom;
-        // Increment the subunitNumber if this subunitMatch was the last one in the unit atom (because we have logic above to "complete" partial subunits which span to the next unit atom, this effectively means that the subunitMatch will be the last in the subunit there are more matches in this atom, or if the extended unit has more matches than the unit does.
-        if (subunitMatches.length < extendedSubunitMatches.length || subunitMatchIndex < subunitMatches.length - 1) {
+        // Increment the subunitNumber if one of the following is true:
+        // * This subunitMatch was the last one in the unit atom (because we have logic above to "complete" partial subunits which span to the next unit atom, this effectively means that the subunitMatch will be the last in the subunit).
+        // * There are more matches in this atom (meaning this atom contains at least one more subunit's start in it).
+        // * The extended unit has more matches than the unit does (meaning that the next atom will contain the start of a new subunit).
+        // * The next atom's content is now empty (meaning that this atom has reached the end of the subunit, and the atom after the next will start a new subunit).
+        if (subunitMatches.length < extendedSubunitMatches.length || subunitMatchIndex < subunitMatches.length - 1 || nextUnitAtomContent.isEmpty) {
           subunitNumber++;
         }
       }


### PR DESCRIPTION
Fixed issue where sentences which didn't contain their period in their last atom wouldn't remove the closing period.
Fixed issue where atoms which, which the previous atom consumed all either text to finish its subunit, leaving the atom with no content left, were not iterating the subunit count, causing the next subunit to be part of the previous one.