### PR TITLE
Add logic to process *** section breaks

### DIFF
--- a/lib/transliterator/result/non_empty_result.dart
+++ b/lib/transliterator/result/non_empty_result.dart
@@ -16,4 +16,7 @@ abstract class NonEmptyResult<E, I, S extends Script, T extends Script> extends 
         return ResultSet<E, S, T>.fromIterable(source, targets);
     }
   }
+
+  /// Creates a new NonEmptyResult with the same [source] as this, but whose [target] is different value.
+  NonEmptyResult<E, I, S, T> withNewTarget(I newTarget);
 }

--- a/lib/transliterator/result/result_pair.dart
+++ b/lib/transliterator/result/result_pair.dart
@@ -5,6 +5,10 @@ class ResultPair<E, S extends Script, T extends Script> extends NonEmptyResult<E
 
   const ResultPair.fromValue(E value) : super(value, value);
 
+  /// Creates a new ResultPair with the same [source] as this, but whose [target] is different value.
+  @override
+  ResultPair<E, S, T> withNewTarget(E newTarget) => ResultPair<E, S, T>(source, newTarget);
+
   @override
   String toString() => '[$source => $target]';
 }

--- a/lib/transliterator/result/result_set.dart
+++ b/lib/transliterator/result/result_set.dart
@@ -2,10 +2,14 @@ part of womens_script_transliterator;
 
 class ResultSet<E, S extends Script, T extends Script> extends NonEmptyResult<E, LinkedHashSet<E>, S, T> {
   ResultSet(E source, LinkedHashSet<E> targets)
-      : assert(targets.isNotEmpty, 'At least one transliteration must be provided. Use `EmptyResult` to represent a Result with no transliterations.'),
+      : assert(targets.isNotEmpty, 'At least one target must be provided. Use `EmptyResult` to represent a Result with no targets.'),
         super(source, targets);
 
-  ResultSet.fromIterable(E sourceWord, Iterable<E> transliterations) : this(sourceWord, transliterations = LinkedHashSet<E>.of(transliterations));
+  ResultSet.fromIterable(E sourceWord, Iterable<E> targets) : this(sourceWord, targets = LinkedHashSet<E>.of(targets));
+
+  /// Creates a new NonEmptyResult with the same [source] as this, but whose [target] is different value.
+  @override
+  ResultSet<E, S, T> withNewTarget(Iterable<E> newTarget) => ResultSet<E, S, T>(source, LinkedHashSet<E>.of(newTarget));
 
   @override
   String toString() => '[$source => ${target.join(',')}]';

--- a/lib/transliterator/transliterator/string/paragraph_transliterator.dart
+++ b/lib/transliterator/transliterator/string/paragraph_transliterator.dart
@@ -18,6 +18,43 @@ class ParagraphTransliterator<S extends Script, T extends Script> extends String
       );
 
   @override
+  Iterable<Result<Atom<Paragraph, X>, S, T>?> transliterateAtoms<X>(Iterable<Atom<StringUnit, X>?> unitAtoms) {
+    final String paragraphText = unitAtoms.map((Atom<StringUnit, X>? atom) => atom?.content.content).join();
+
+    // Process any paragraphs whose contents only consist of non-alphabetical characters in a special manner (since transliteration should only be applied to words). By returning the result of this directly without calling super.transliterateAtoms(), the normal logic which recurses down the Unit hierarchy will be short-circuited and further processing prevented.
+    //TODO: This is a very Latin-centric regex. In an ideal world, the regex being used would be based on the value of [S] so that it can properly detect which characters are used in words in the source Script.
+    if (!paragraphText.contains(RegExp('[a-zA-Z]'))) {
+      return processWordlessParagraphs(unitAtoms);
+    }
+
+    // Any paragraphs that have letters in them should be processed as normal. Pass them along to the super method which will break them into sentences and continue the transliteration at that Unit level.
+    return super.transliterateAtoms(unitAtoms);
+  }
+
+  /// Application of special rules for transliterating any paragraphs which don't contain any words. Such paragraphs will frequently have symbolic glyphs meant as visual decoration rather than any semantic meaning, and this may not translate well if left unchanged. Alternatively, a wordless paragraph might simply have content which otherwise would be mangled in an undesirable manner should it be passed down to the [SentenceTransliterator] and [WordTransliterator]. While it is generally the case that these paragraphs only contain a single "word" or at most, a "sentence," it is important that this special behavior happen up at the [ParagraphTransliterator] level, because the behavior of lower level [StringTransliterator]s may prevent the desired result from being achieved (e.g., the [SentenceTransliterator] may attempt to add a leading period and/or remove a trailing period, despite these paragraphs not containing anything that is semantically a "sentence").
+  Iterable<Result<Atom<Paragraph, X>, S, T>?> processWordlessParagraphs<X>(Iterable<Atom<StringUnit, X>?> unitAtoms) {
+    final Iterable<Atom<StringUnit, X>> nonNullUnitAtoms = unitAtoms.whereType<Atom<StringUnit, X>>();
+    final String paragraphText = nonNullUnitAtoms.map((Atom<StringUnit, X>? atom) => atom?.content.content).join();
+
+    // Asterisks are often used as section breaks, but won't really display well in fonts like Women's Script. Convert them to underscores to get a nice looking line to separate the sections instead. A source really oughtn't break up such a section break across multiple Atoms, but in the event it does, the new section break will replace only the first Atom of the Paragraph, with the content of any subsequent Atoms being removed.
+    // TODO: This logic only makes sense in the context of English to Alethi transliteration. In an ideal world, this type of replacement would exist somewhere in the TransliterationRule paradigm and thus its application would depend on the transliteration context.
+    if (paragraphText.contains(RegExp(r'^\s*\*(\s*\*){2,4}\s*$'))) {
+      final Atom<Paragraph, X> firstAtom = Atom<Paragraph, X>(buildUnit(nonNullUnitAtoms.first.content.content), nonNullUnitAtoms.first.context);
+      return <Result<Atom<StringUnit, X>, S, T>>[
+        ResultPair<Atom<StringUnit, X>, S, T>(firstAtom, firstAtom.withNewContent(buildUnit('__________'))),
+        ...nonNullUnitAtoms.skip(1).map(EmptyResult<Atom<StringUnit, X>, S, T>.new)
+      ].map<Result<Atom<Paragraph, X>, S, T>>(
+          // Transform each Result into one of the proper type (a Result of Atoms of Paragraphs)
+          (Result<Atom<StringUnit, X>, S, T> result) =>
+              result.cast<Atom<Paragraph, X>>((Atom<StringUnit, X> atom) => Atom<Paragraph, X>(buildUnit(atom.content.content), atom.context)));
+    }
+
+    // If the content wasn't of a type which required unique changes, simply return Results in which the original content remains unchanged.
+    return nonNullUnitAtoms.map<Result<Atom<Paragraph, X>, S, T>>(
+        (Atom<StringUnit, X> atom) => ResultPair<Atom<Paragraph, X>, S, T>.fromValue(Atom<Paragraph, X>(buildUnit(atom.content.content), atom.context)));
+  }
+
+  @override
   SentenceTransliterator<S, T> getSubtransliterator() => SentenceTransliterator.fromTransliterator<S, T>(this);
 
   @override

--- a/lib/transliterator/transliterator/string/string_transliterator.dart
+++ b/lib/transliterator/transliterator/string/string_transliterator.dart
@@ -78,8 +78,8 @@ mixin SuperUnitStringTransliterator<U extends StringUnit, S extends Script, T ex
     ).cast<U>((Subunit<U> subunit) => subunit.cast<U>());
   }
 
-  // TODO: The type constraint on this is weaker than it should be. Ideally it'd accept List<Atom<Unit, X>>, but if it gets passed something of type Subunit<E> where E is the superunit of Unit, it won't accept those as being the same. The weaker type restriction is a work around until I figure out a better solution.
-  /// Takes a [List] of [Atom]s whose contents collectively represent one [StringUnit]'s content, and returns the results of transliteration on them.
+  // TODO: The type constraint on this is weaker than it should be. Ideally it'd accept Iterable<Atom<Unit, X>?>, but if it gets passed something of type Subunit<E> where E is the superunit of Unit, it won't accept those as being the same. The weaker type restriction is a work around until I figure out a better solution.
+  /// Takes an [Iterable] of [Atom]s whose contents collectively represent one [StringUnit]'s content, and returns the [Result]s of transliteration on them.
   Iterable<AtomResult<U, X, S, T>?> transliterateAtoms<X>(Iterable<Atom<StringUnit, X>?> unitAtoms) {
     final SubTrans<U, S, T> subtransliterator = getSubtransliterator();
 


### PR DESCRIPTION
Resolves #30

Added a place for special logic to be processed in the ParagraphTransliterator which allows these types of section breaks to be handled without the SentenceTransliterator causing problems.